### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [4/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -11,6 +11,9 @@
   "deployment": {
     "nova_dashboard": {
       "crowbar-revision": 0,
+      "element_states": {
+        "nova_dashboard-server": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "nova_dashboard-server" ]

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -31,6 +31,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 .../crowbar/bc-template-nova_dashboard.json        |    3 +++
 .../crowbar/bc-template-nova_dashboard.schema      |   10 ++++++++++
 2 files changed, 13 insertions(+), 0 deletions(-)
