### PR TITLE
Update development tree to use Folsom as our base Openstack distro. [2/6]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -43,6 +43,7 @@ debs:
     repos:
       - deb http://ops.rcb.me/packages oneiric diablo-final
   ubuntu-12.04:
+    repos:
       - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/folsom main
     pkgs:
       - python-django-horizon


### PR DESCRIPTION
This pulls in the updates from the feature/folsom branch to hopefully
cause us to build and deploy on Folsom instead of Essex.

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)
