### PR TITLE
Add os_support stanzas to selected barclamps. [3/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -25,6 +25,8 @@ barclamp:
     - keystone
   member:
     - openstack
+  os_support:
+    - ubuntu-12.04
 
 crowbar:
   layout: 2
@@ -33,15 +35,6 @@ crowbar:
   chef_order: 90
 
 debs:
-  ubuntu-10.10:
-    repos:
-      - deb http://ops.rcb.me/packages maverick diablo-final
-  ubuntu-11.04:
-    repos:
-      - deb http://ops.rcb.me/packages natty diablo-final
-  ubuntu-11.10:
-    repos:
-      - deb http://ops.rcb.me/packages oneiric diablo-final
   ubuntu-12.04:
     repos:
       - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/folsom main
@@ -58,14 +51,4 @@ debs:
     - python-glance
     - python-novaclient
     - python-swift
-    
-rpms:
-  pkgs:
-    # put your rpms here
-    # - httpd
-    
-gems:
-  pkgs:
-    # put your gems here.
-    # - i18n
 


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |   21 ++-------------------
 1 file changed, 2 insertions(+), 19 deletions(-)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
