### PR TITLE
prevent syncdb from prompting for silly questions, and prevet this error...

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -149,7 +149,7 @@ Chef::Log.info("Keystone server found at #{keystone_address}")
 execute "python manage.py syncdb" do
   cwd "/usr/share/openstack-dashboard"
   environment ({'PYTHONPATH' => '/usr/share/openstack-dashboard/'})
-  command "python manage.py syncdb"
+  command "python manage.py syncdb --noinput"
   user "www-data"
   action :nothing
   notifies :restart, resources(:service => "apache2"), :immediately


### PR DESCRIPTION
...:

[Fri, 25 Jan 2013 14:44:22 -0600] INFO: template[/etc/openstack-dashboard/local_settings.py] sending run action to execute[python manage.py syncdb](immediate)
[Fri, 25 Jan 2013 14:44:22 -0600] INFO: Processing execute[python manage.py syncdb] action run (nova_dashboard::server line 149)
# 
# Error executing action `run` on resource 'execute[python manage.py syncdb]'
## Mixlib::ShellOut::ShellCommandFailed

Expected process to exit with [0], but received '1'
---- Begin output of python manage.py syncdb ----
STDOUT: Creating tables ...
Creating table django_content_type
Creating table auth_permission
Creating table auth_group_permissions
Creating table auth_group
Creating table auth_user_user_permissions
Creating table auth_user_groups
Creating table auth_user
Creating table django_session

You just installed Django's auth system, which means you don't have any superusers defined.
Would you like to create one now? (yes/no):
