### PR TITLE
change to pkg by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -29,7 +29,7 @@
         "pip://python-quantumclient>=2.0",
         "pip://pytz"
       ],
-      "use_gitrepo": true
+      "use_gitrepo": false
     }
   },
   "deployment": {


### PR DESCRIPTION
dunno why all other barclamps uses pkgs, but nova_dashboard use pfs, seems like an mistake for me
