### PR TITLE
Fixing description for OS barclamps [7/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -19,7 +19,7 @@ barclamp:
   name: nova_dashboard
   display: Nova Dashboard
 #  description: User Interface for OpenStack projects (aka code name Horizon)
-  description: OpenStack Dashboard: graphical interface to access, provision and automate cloud-based resources
+  description: 'OpenStack Dashboard: graphical interface to access, provision and automate cloud-based resources'
   version: 0
   requires:
     - keystone


### PR DESCRIPTION
Chnaged description for swift, glance, tempest, nova_dashboard, cinder, quantum and nova to match ones in OS.
Decsriptions for all these components are no defined in crowbar.yml instead of scattered between chef/data_bags and yml.

 crowbar.yml |    3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: b671718679ec72e1f12a8a35bc36e8d102d1772c

Crowbar-Release: pebbles
