### PR TITLE
Fix for DE1208(Unable to login to Horizon if Cinder installed on non-controller machine)

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -34,8 +34,6 @@ MAILER_EMAIL_BACKEND = EMAIL_BACKEND
 # EMAIL_HOST_USER = 'djangomail'
 # EMAIL_HOST_PASSWORD = 'top-secret!'
 
-OPENSTACK_ENDPOINT_TYPE = "internalURL"
-
 
 HORIZON_CONFIG = {
     'dashboards': ('nova', 'syspanel', 'settings',),

--- a/crowbar_framework/app/models/nova_dashboard_service.rb
+++ b/crowbar_framework/app/models/nova_dashboard_service.rb
@@ -142,6 +142,13 @@ class NovaDashboardService < ServiceObject
       node.crowbar["crowbar"]["links"]["Nova Dashboard"] = "http://#{server_ip}/"
       node.save
     end
+
+    #enable public iface on horizon node
+    all_nodes.each do |n|
+      net_svc.allocate_ip "default", "public", "host", n
+    end
+
+
     @logger.debug("Nova_dashboard apply_role_pre_chef_call: leaving")
   end
 


### PR DESCRIPTION
Unable to login to Horizon if Cinder installed on non-controller machine

By design nova_dashboard comes without public ip, so we should use internal network to interact with other services, otherwise if one of services wiil be installed not on the same node nova_dashboard will not able to reach them.
