### PR TITLE
enforcing single proposal for all openstack barclamps [8/9]

### DIFF
--- a/crowbar_framework/app/models/nova_dashboard_service.rb
+++ b/crowbar_framework/app/models/nova_dashboard_service.rb
@@ -20,8 +20,9 @@ class NovaDashboardService < ServiceObject
     @logger = thelogger
   end
 
+# Turn off multi proposal support till it really works and people ask for it.
   def self.allow_multiple_proposals?
-    true
+    false
   end
 
   def proposal_dependencies(role)


### PR DESCRIPTION
setup allow_multiple_proposals to false for cinder, database, glance, keystone, nova, nova_dashboard, quantum rabbitmq, and swift.

 .../app/models/nova_dashboard_service.rb           |    3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 79c57cd7d40ba8de015310df1f8f9e8b30a9b020

Crowbar-Release: pebbles
