### PR TITLE
Only define SECRET_KEY on SUSE to avoid crash on Ubuntu

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -64,8 +64,10 @@ OPENSTACK_KEYSTONE_BACKEND = {
 API_PAGINATE_LIMIT = 1000
 SWIFT_PAGINATE_LIMIT = 1000
 
+<% if node.platform == "suse" -%>
 from horizon.utils import secret_key
 SECRET_KEY = secret_key.generate_or_read_from_file(os.path.join(LOCAL_PATH, '.secret_key_store'))
+<% end -%>
 
 # If you have external monitoring links
 # EXTERNAL_MONITORING = [


### PR DESCRIPTION
This is a temporary workaround, to unbreak Ubuntu. I think SECRET_KEY
should still be defined there.

NOTE: this is completely untested. I'm doing a quick pull request to suggest a fix that should unbreak stuff, but please test before merging.
