### PR TITLE
Remove possibility to use sqlite

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -131,93 +131,73 @@ end
 
 node.set_unless['dashboard']['db']['password'] = secure_password
 
-database_engine = node[:nova_dashboard][:database_engine]
-
-if database_engine == "database"
-    Chef::Log.info("Configuring Horizion to use database backend")
-
-    env_filter = " AND database_config_environment:database-config-#{node[:nova_dashboard][:database_instance]}"
-    sqls = search(:node, "roles:database-server#{env_filter}") || []
-    if sqls.length > 0
-        sql = sqls[0]
-        sql = node if sql.name == node.name
-    else
-        sql = node
-    end
-    include_recipe "database::client"
-    backend_name = Chef::Recipe::Database::Util.get_backend_name(sql)
-    include_recipe "#{backend_name}::client"
-    include_recipe "#{backend_name}::python-client"
-
-    db_provider = Chef::Recipe::Database::Util.get_database_provider(sql)
-    db_user_provider = Chef::Recipe::Database::Util.get_user_provider(sql)
-    privs = Chef::Recipe::Database::Util.get_default_priviledges(sql)
-    case backend_name
-    when "mysql"
-        django_db_backend = "'django.db.backends.mysql'"
-    when "postgresql"
-        django_db_backend = "'django.db.backends.postgresql_psycopg2'"
-    end
-
-    database_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "admin").address if database_address.nil?
-    Chef::Log.info("Database server found at #{database_address}")
-    db_conn = { :host => database_address,
-                :username => "db_maker",
-                :password => sql[database_engine][:db_maker_password] }
-
-
-    # Create the Dashboard Database
-    database "create #{node[:dashboard][:db][:database]} database" do
-        connection db_conn
-        database_name node[:dashboard][:db][:database]
-        provider db_provider
-        action :create
-    end
-
-    database_user "create dashboard database user" do
-        connection db_conn
-        database_name node[:dashboard][:db][:database]
-        username node[:dashboard][:db][:user]
-        password node[:dashboard][:db][:password]
-        host '%'
-        provider db_user_provider
-        action :create
-    end
-
-    database_user "create dashboard database user" do
-        connection db_conn
-        database_name node[:dashboard][:db][:database]
-        username node[:dashboard][:db][:user]
-        password node[:dashboard][:db][:password]
-        host '%'
-        privileges privs
-        provider db_user_provider
-        action :grant
-    end
-
-    db_settings = {
-      'ENGINE' => django_db_backend,
-      'NAME' => "'#{node[:dashboard][:db][:database]}'",
-      'USER' => "'#{node[:dashboard][:db][:user]}'",
-      'PASSWORD' => "'#{node[:dashboard][:db][:password]}'",
-      'HOST' => "'#{database_address}'",
-      'default-character-set' => "'utf8'"
-    }
-elsif node[:nova_dashboard][:database_engine] == "sqlite"
-   Chef::Log.info("Configuring Horizion to use SQLite3 backend")
-    db_settings = {
-      'ENGINE' => "'django.db.backends.sqlite3'",
-      'NAME' => "os.path.join(LOCAL_PATH, 'dashboard_openstack.sqlite3')"
-    }
-
-    file "/etc/openstack-dashboard/dashboard_openstack.sqlite3" do
-        action :touch
-        user node[:apache][:user]
-        group node[:apache][:group]
-    end
+env_filter = " AND database_config_environment:database-config-#{node[:nova_dashboard][:database_instance]}"
+sqls = search(:node, "roles:database-server#{env_filter}") || []
+if sqls.length > 0
+    sql = sqls[0]
+    sql = node if sql.name == node.name
 else
-    Chef::Log.error("Unknown database engine #{database_engine}")
+    sql = node
 end
+include_recipe "database::client"
+backend_name = Chef::Recipe::Database::Util.get_backend_name(sql)
+include_recipe "#{backend_name}::client"
+include_recipe "#{backend_name}::python-client"
+
+db_provider = Chef::Recipe::Database::Util.get_database_provider(sql)
+db_user_provider = Chef::Recipe::Database::Util.get_user_provider(sql)
+privs = Chef::Recipe::Database::Util.get_default_priviledges(sql)
+case backend_name
+when "mysql"
+    django_db_backend = "'django.db.backends.mysql'"
+when "postgresql"
+    django_db_backend = "'django.db.backends.postgresql_psycopg2'"
+end
+
+database_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "admin").address if database_address.nil?
+Chef::Log.info("Database server found at #{database_address}")
+db_conn = { :host => database_address,
+            :username => "db_maker",
+            :password => sql["database"][:db_maker_password] }
+
+
+# Create the Dashboard Database
+database "create #{node[:dashboard][:db][:database]} database" do
+    connection db_conn
+    database_name node[:dashboard][:db][:database]
+    provider db_provider
+    action :create
+end
+
+database_user "create dashboard database user" do
+    connection db_conn
+    database_name node[:dashboard][:db][:database]
+    username node[:dashboard][:db][:user]
+    password node[:dashboard][:db][:password]
+    host '%'
+    provider db_user_provider
+    action :create
+end
+
+database_user "create dashboard database user" do
+    connection db_conn
+    database_name node[:dashboard][:db][:database]
+    username node[:dashboard][:db][:user]
+    password node[:dashboard][:db][:password]
+    host '%'
+    privileges privs
+    provider db_user_provider
+    action :grant
+end
+
+db_settings = {
+  'ENGINE' => django_db_backend,
+  'NAME' => "'#{node[:dashboard][:db][:database]}'",
+  'USER' => "'#{node[:dashboard][:db][:user]}'",
+  'PASSWORD' => "'#{node[:dashboard][:db][:password]}'",
+  'HOST' => "'#{database_address}'",
+  'default-character-set' => "'utf8'"
+}
 
 # Need to figure out environment filter
 env_filter = " AND keystone_config_environment:keystone-config-#{node[:nova_dashboard][:keystone_instance]}"

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -3,7 +3,6 @@
   "description": "User Interface for OpenStack projects (code name Horizon)",
   "attributes": {
     "nova_dashboard": {
-      "database_engine": "database",
       "nova_instance": "none",
       "keystone_instance": "none",
       "database_instance": "none",

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -12,7 +12,6 @@
           "type": "map",
           "required": true,
           "mapping": {
-            "database_engine": { "type": "str", "required": true },
             "nova_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "database_instance": { "type": "str", "required": true },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -78,7 +78,6 @@ locale_additions:
       nova_dashboard:
         edit_attributes: 
           attributes: Attributes
-          database_engine: Database Engine
           database_instance: Database Instance
           keystone_instance: Keystone Instance
           nova_instance: Nova Instance

--- a/crowbar_framework/app/models/nova_dashboard_service.rb
+++ b/crowbar_framework/app/models/nova_dashboard_service.rb
@@ -27,9 +27,7 @@ class NovaDashboardService < ServiceObject
 
   def proposal_dependencies(role)
     answer = []
-    if role.default_attributes["nova_dashboard"]["database_engine"] == "database"
-      answer << { "barclamp" => "database", "inst" => role.default_attributes["nova_dashboard"]["database_instance"] }
-    end
+    answer << { "barclamp" => "database", "inst" => role.default_attributes["nova_dashboard"]["database_instance"] }
     if role.default_attributes[@bc_name]["use_gitrepo"]
       answer << { "barclamp" => "git", "inst" => role.default_attributes[@bc_name]["git_instance"] }
     end
@@ -61,19 +59,14 @@ class NovaDashboardService < ServiceObject
       end
       if dbs.empty?
         @logger.info("Dashboard create_proposal: no database proposal found")
-        base["attributes"]["nova_dashboard"]["database_engine"] = ""
       else
         base["attributes"]["nova_dashboard"]["database_instance"] = dbs[0]
-        base["attributes"]["nova_dashboard"]["database_engine"] = "database"
       end
     rescue
       @logger.info("Nova dashboard create_proposal: no database found")
-      base["attributes"]["nova_dashboard"]["database_engine"] = ""
     end
 
-    # SQLite is not a fallback solution
-    # base["attributes"]["nova_dashboard"]["database_engine"] = "sqlite" if base["attributes"]["nova_dashboard"]["database_engine"] == ""
-    if base["attributes"]["nova_dashboard"]["database_engine"] == ""
+    if base["attributes"]["nova_dashboard"]["database_instance"] == ""
       raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "database"))
     end
 


### PR DESCRIPTION
It's known to be broken, and there was agreement to only use the
database barclamp.

This means we can remove the whole database_engine dance, which
simplifies things

Note: changes in server.rb look big but are mostly indentation-related due to removal of an "if" statement.
