### PR TITLE
Add non-configurable attribute for http/https use in keystone [7/7]

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -238,6 +238,7 @@ end
 
 keystone_address = keystone["keystone"]["address"] rescue nil
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
 Chef::Log.info("Keystone server found at #{keystone_address}")
 
@@ -257,6 +258,7 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
   group "root"
   mode "0640"
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_address => keystone_address,
     :keystone_service_port => keystone_service_port,
     :db_settings => db_settings,

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -54,7 +54,7 @@ HORIZON_CONFIG = {
 COMPRESS_OFFLINE = <%= @compress_offline ? "True" : "False" %>
 
 OPENSTACK_HOST = "<%= @keystone_address %>"
-OPENSTACK_KEYSTONE_URL = "http://%s:<%= @keystone_service_port %>/v2.0" % OPENSTACK_HOST
+OPENSTACK_KEYSTONE_URL = "<%= @keystone_protocol %>://%s:<%= @keystone_service_port %>/v2.0" % OPENSTACK_HOST
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "Member"
 OPENSTACK_KEYSTONE_BACKEND = {
     'name': 'native',


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
