### PR TITLE
Fix CHEF-3694 caused by bad resource naming

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -179,7 +179,7 @@ database_user "create dashboard database user" do
     action :create
 end
 
-database_user "create dashboard database user" do
+database_user "grant database access for dashboard database user" do
     connection db_conn
     database_name node[:dashboard][:db][:database]
     username node[:dashboard][:db][:user]


### PR DESCRIPTION
Two resources have the same name, which leads to:

Cloning resource attributes for database_user[create dashboard database user] from prior resource (CHEF-3694)
Previous database_user[create dashboard database user]: /var/chef/cache/cookbooks/nova_dashboard/recipes/server.rb:177:in `from_file'
Current  database_user[create dashboard database user]: /var/chef/cache/cookbooks/nova_dashboard/recipes/server.rb:187:in`from_file'
