### PR TITLE
Additional fixes for keystone SSL support [3/3]

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -220,6 +220,7 @@ keystone_address = keystone["keystone"]["address"] rescue nil
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
 keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
+keystone_insecure = keystone_protocol == 'https' && keystone[:keystone][:ssl][:insecure]
 Chef::Log.info("Keystone server found at #{keystone_address}")
 
 execute "python manage.py syncdb" do
@@ -241,6 +242,7 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
     :keystone_protocol => keystone_protocol,
     :keystone_address => keystone_address,
     :keystone_service_port => keystone_service_port,
+    :insecure => keystone_insecure,
     :db_settings => db_settings,
     :compress_offline => node.platform == "suse"
   )

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -60,6 +60,7 @@ OPENSTACK_KEYSTONE_BACKEND = {
     'name': 'native',
     'can_edit_user': True
 }
+OPENSTACK_SSL_NO_VERIFY = <%= @insecure ? "True" : "False" %>
 
 API_PAGINATE_LIMIT = 1000
 SWIFT_PAGINATE_LIMIT = 1000


### PR DESCRIPTION
The default for cert_required is wrong (should be false, like upstream).

Also add an attribute to let the user declare that the certificate is insecure; this will be usable from other barclamps if they need to use --insecure options here and there (quantum needs it, for instance).

Crowbar-Pull-ID: 49beb953652e66e14d4600b5509dd9eb9eb2e1cb

Crowbar-Release: pebbles
