### PR TITLE
Use FQDN instead of IP address to point to keystone host

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -224,12 +224,11 @@ if node[:nova_dashboard][:use_gitrepo]
   end
 end
 
-keystone_address = keystone["keystone"]["address"] rescue nil
-keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_host = keystone[:fqdn]
 keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
 keystone_insecure = keystone_protocol == 'https' && keystone[:keystone][:ssl][:insecure]
-Chef::Log.info("Keystone server found at #{keystone_address}")
+Chef::Log.info("Keystone server found at #{keystone_host}")
 
 quantums = search(:node, "roles:quantum-server") || []
 if quantums.length > 0
@@ -266,7 +265,7 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
   variables(
     :debug => node[:nova_dashboard][:debug],
     :keystone_protocol => keystone_protocol,
-    :keystone_address => keystone_address,
+    :keystone_host => keystone_host,
     :keystone_service_port => keystone_service_port,
     :insecure => keystone_insecure || quantum_insecure || nova_insecure,
     :db_settings => db_settings,

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -64,7 +64,7 @@ HORIZON_CONFIG = {
 
 COMPRESS_OFFLINE = <%= @compress_offline ? "True" : "False" %>
 
-OPENSTACK_HOST = "<%= @keystone_address %>"
+OPENSTACK_HOST = "<%= @keystone_host %>"
 OPENSTACK_KEYSTONE_URL = "<%= @keystone_protocol %>://%s:<%= @keystone_service_port %>/v2.0" % OPENSTACK_HOST
 OPENSTACK_KEYSTONE_DEFAULT_ROLE = "Member"
 OPENSTACK_KEYSTONE_BACKEND = {


### PR DESCRIPTION
When using SSL, the common name field in the certificates is checked,
and using IP addresses won't work with that.

Internally to the OpenStack setup, it is always fine to use the FQDN
from the node, so we use this.
