### PR TITLE
Add apache2 dependency to cookbook

### DIFF
--- a/chef/cookbooks/nova_dashboard/metadata.rb
+++ b/chef/cookbooks/nova_dashboard/metadata.rb
@@ -5,6 +5,7 @@ description      "Installs/Configures Nova Dashboard"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.me'))
 version          "0.0"
 
+depends "apache2"
 depends "openssl"
 depends "database"
 depends "nagios"


### PR DESCRIPTION
This worked out by luck so far, but it should really be there.
