### PR TITLE
Horizon should only be titled "Dashboard"

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -17,7 +17,7 @@
 
 barclamp:
   name: nova_dashboard
-  display: Nova Dashboard
+  display: Dashboard
 #  description: User Interface for OpenStack projects (aka code name Horizon)
   description: 'OpenStack Dashboard: graphical interface to access, provision and automate cloud-based resources'
   version: 0


### PR DESCRIPTION
It grew far beyond Nova and breaks the SUSE branding :-) 

http://wstaw.org/m/2013/08/09/title.png
