### PR TITLE
webui: Use sections to group options belonging together

### DIFF
--- a/crowbar_framework/app/views/barclamp/nova_dashboard/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/nova_dashboard/_edit_attributes.html.haml
@@ -9,9 +9,9 @@
     = render_instance_selector("keystone", :keystone_instance, t('.keystone_instance'), "keystone_instance", @proposal)
     = render_instance_selector("nova", :nova_instance, t('.nova_instance'), "nova_instance", @proposal)
 
-  %label.h3{ :for => :ssl }= t('.ssl')
-  %div.container{ :id => :ssl }
-    %p.h3
+  %label.section-header{ :for => :protocol_div }= t('.ssl')
+  %div.section{ :id => :protocol_div }
+    %p
       %label{ :for => :protocol }= t('.protocol')
       = select_tag :protocol, options_for_select([['HTTP','false'], ['HTTPS', 'true']], @proposal.raw_data['attributes'][@proposal.barclamp]["apache"]["ssl"].to_s), :onchange => "update_value('apache/ssl', 'protocol', 'boolean')"
 


### PR DESCRIPTION
This depends on https://github.com/crowbar/barclamp-crowbar/pull/667 to really work as intended, although it doens't harm to have this go in without the other pull request.

Just to be clear: this doesn't remove any option from the webui (nor is it adding anything). It's just moving things around, and adding section headers.
