### PR TITLE
Reenable running nova_dashboard and swift on same node [3/3]

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -30,3 +30,6 @@ node[:nova_dashboard][:monitor]={}
 node[:nova_dashboard][:monitor][:svcs] = []
 node[:nova_dashboard][:monitor][:ports]={}
 
+# Use a non-default port for memcached to avoid collision with swift
+node[:nova_dashboard][:memcached] = {}
+node[:nova_dashboard][:memcached][:port] = 11212

--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -274,7 +274,13 @@ end
 
 
 # We're going to use memcached as a cache backend for Django
-memcached_instance "nova-dashboard"
+#
+# Do not use the default port, since this will collide with swift
+# if it happens to be installed on the same node
+memcached_instance "nova-dashboard" do
+  port node[:nova_dashboard][:memcached][:port]
+end
+
 case node[:platform]
 when "suse"
   package "python-python-memcached"

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -78,7 +78,7 @@ SECRET_KEY = secret_key.generate_or_read_from_file(os.path.join(LOCAL_PATH, '.se
 CACHES = {
    'default': {
        'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',
-       'LOCATION' : '<%= "127.0.0.1:#{node[:memcached][:port]}" %>',
+       'LOCATION' : '<%= "127.0.0.1:#{node[:nova_dashboard][:memcached][:port]}" %>',
    }
 }
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds execute permission back to the nova smoktest script so that it is executed as part of the smoketest
- Changes the instance of memcached that nova_dashboard spawns to use port 11212 instead of the default port 11211.  This fixes a regression where nova_dashboard and swift can no longer be installed on the same node, which in turn reenables running the nova_dashboard and swift smoketests on the same setup.
- To make the above changes work, a fix to the OpsCode memcached_instance recipe was merged in so that it would not ignore the port specification.
  
  .../cookbooks/nova_dashboard/attributes/default.rb |    3 +++
  chef/cookbooks/nova_dashboard/recipes/server.rb    |    8 +++++++-
  .../templates/default/local_settings.py.erb        |    2 +-
  3 files changed, 11 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 0a2d343d5a3fdb6cb5f0ee49feb6270348a6afe7

Crowbar-Release: pebbles
