### PR TITLE
Added link for access nova dashboard from admin network [2/2]

### DIFF
--- a/crowbar_framework/app/models/nova_dashboard_service.rb
+++ b/crowbar_framework/app/models/nova_dashboard_service.rb
@@ -147,10 +147,12 @@ class NovaDashboardService < ServiceObject
     # Make sure the nodes have a link to the dashboard on them.
     all_nodes.each do |n|
       node = NodeObject.find_node_by_name(n)
-      server_ip = node.get_network_by_type("public")["address"]
+      public_server_ip = node.get_network_by_type("public")["address"]
       node.crowbar["crowbar"] = {} if node.crowbar["crowbar"].nil?
       node.crowbar["crowbar"]["links"] = {} if node.crowbar["crowbar"]["links"].nil?
-      node.crowbar["crowbar"]["links"]["Nova Dashboard"] = "http://#{server_ip}/"
+      node.crowbar["crowbar"]["links"]["Nova Dashboard (public)"] = "http://#{public_server_ip}/"
+      admin_server_ip = node.get_network_by_type("admin")["address"]
+      node.crowbar["crowbar"]["links"]["Nova Dashboard (admin)"] = "http://#{admin_server_ip}/"
       node.save
     end
     @logger.debug("Nova_dashboard apply_role_pre_chef_call: leaving")


### PR DESCRIPTION
The Nova Dashboard link was changed in the past so that it tries to access the
Nova Dashboard on the public IP address.  This will only work if you are
accessing the Crowbar GUI over a public IP, which in turn you can only do if a
public IP has been assigned to the admin node via a manual CLI command.

Because there is no routing between the admin and public networks, if you are
running the Crowbar GUI from a system on the admin network, the link will not
work.

This fix renames the "Nova Dashboard" link to "Nova Dashboard (public)" and
adds an additional link called "Nova Dashboard (admin)" so that the dashboard
can be accessed from a browser running on a system in either network.

Also added sorting to the links for a little polish.

 .../app/models/nova_dashboard_service.rb           |    6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 258608da6e26a0df1972264ab112042f1ef6d9c0

Crowbar-Release: roxy
