### PR TITLE
Use shared memcached instance, but set a Key prefix

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -30,6 +30,3 @@ node[:nova_dashboard][:monitor]={}
 node[:nova_dashboard][:monitor][:svcs] = []
 node[:nova_dashboard][:monitor][:ports]={}
 
-# Use a non-default port for memcached to avoid collision with swift
-node[:nova_dashboard][:memcached] = {}
-node[:nova_dashboard][:memcached][:port] = 11212

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -107,7 +107,7 @@ SECRET_KEY = secret_key.generate_or_read_from_file(os.path.join(LOCAL_PATH, '.se
 CACHES = {
     'default': {
         'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION' : '<%= "127.0.0.1:#{node[:nova_dashboard][:memcached][:port]}" %>',
+        'LOCATION' : '<%= @memcache_listen %>:<%= node[:memcached][:port] %>',
     }
 }
 


### PR DESCRIPTION
Swift caching hashes its keys with md5, so the only thing needed
to avoid lookup collisions is to add a unique prefix to the nova
dashboard memcache keys. The 2nd instance of memcached needed
is difficult on platforms that use systemd/sysvinit for handling
services.

This reverts commit c216e76926ae9065747ea5455da4dfc59ef0c7ba.
