### PR TITLE
Limit Keystone API usage to v2.0

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -32,9 +32,9 @@ ALLOWED_HOSTS = ['*']
 # NOTE: The version should be formatted as it appears in the URL for the
 # service API. For example, The identity service APIs have inconsistent
 # use of the decimal point, so valid options would be "2.0" or "3".
-# OPENSTACK_API_VERSIONS = {
-#     "identity": 3
-# }
+OPENSTACK_API_VERSIONS = {
+    "identity": 2.0
+}
 
 # Set this to True if running on multi-domain model. When this is enabled, it
 # will require user to enter the Domain name in addition to username for login.


### PR DESCRIPTION
This avoids Horizon using the v3 api, which is not properly
set up. We don't support it at the moment anyway (we hardcode /v2.0
almost everywhere).
