### PR TITLE
Cisco ml2 driver is not compatible with n1kv panel

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -255,9 +255,11 @@ if neutrons.length > 0
   neutron = neutrons[0]
   neutron_insecure = neutron[:neutron][:api][:protocol] == 'https' && neutron[:neutron][:ssl][:insecure]
   neutron_networking_plugin = neutron[:neutron][:networking_plugin]
+  neutron_use_ml2 = neutron[:neutron][:use_ml2]
 else
   neutron_insecure = false
   neutron_networking_plugin = ""
+  neutron_use_ml2 = false
 end
 
 env_filter = "AND nova_config_environment:nova-config-#{node[:nova_dashboard][:nova_instance]}"
@@ -319,6 +321,7 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
     :password_validator_help_text => node[:nova_dashboard][:password_validator][:help_text],
     :site_branding => node[:nova_dashboard][:site_branding],
     :neutron_networking_plugin => neutron_networking_plugin,
+    :neutron_use_ml2 => neutron_use_ml2,
     :session_timeout => node[:nova_dashboard][:session_timeout],
     :memcache_listen => node_admin_ip
   )

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -168,7 +168,7 @@ OPENSTACK_NEUTRON_NETWORK = {
     # The profile_support option is used to detect if an external router can be
     # configured via the dashboard. When using specific plugins the
     # profile_support can be turned on if needed.
-<% if @neutron_networking_plugin == "cisco" -%>
+<% if @neutron_networking_plugin == "cisco" && !@neutron_use_ml2 -%>
     'profile_support': 'cisco',
 <% else -%>
     'profile_support': None,


### PR DESCRIPTION
If the ml2 cisco driver is in use, the n1kv panel for horizon should
not be activated
