### PR TITLE
Use helper from database cookbook to get database IP address

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -191,7 +191,7 @@ when "postgresql"
     django_db_backend = "'django.db.backends.postgresql_psycopg2'"
 end
 
-database_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "admin").address if database_address.nil?
+database_address = CrowbarDatabaseHelper.get_listen_address(sql)
 Chef::Log.info("Database server found at #{database_address}")
 db_conn = { :host => database_address,
             :username => "db_maker",


### PR DESCRIPTION
This way we're ready for when HA will be used for database.

This depends on https://github.com/crowbar/barclamp-database/pull/66
