### PR TITLE
Fix regression with memcache possibly listening on wrong address

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -289,6 +289,11 @@ end
 
 
 # We're going to use memcached as a cache backend for Django
+
+# make sure our memcache only listens on the admin IP address
+node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+node[:memcached][:listen] = node_admin_ip
+
 if ha_enabled
   memcached_nodes = CrowbarPacemakerHelper.cluster_nodes(node, "nova_dashboard-server")
   memcached_locations = memcached_nodes.map do |n|
@@ -296,8 +301,6 @@ if ha_enabled
     "#{node_admin_ip}:#{n[:memcached][:port] rescue node[:memcached][:port]}"
   end
 else
-  node_admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-  node[:memcached][:listen] = node_admin_ip
   memcached_locations = [ "#{node_admin_ip}:#{node[:memcached][:port]}" ]
 end
 


### PR DESCRIPTION
With the HA support in commit a541099b, we lost the code ensuring that
memcache only listens where it should (when HA is used; it kept working
fine for non-HA).
