### PR TITLE
Actually set the caching key prefix

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -112,6 +112,9 @@ CACHES = {
           '<%= memcached_location %>',
 <% end -%>
         ]
+        'OPTIONS': {
+          'KEY_PREFIX': '<%= node[:nova_dashboard][:config][:environment] %>'
+        }
     }
 }
 


### PR DESCRIPTION
This was accidentally missing in a rebase of
https://github.com/crowbar/barclamp-nova_dashboard/pull/121
