### PR TITLE
Use the same password for proposal and role on migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/nova_dashboard/004_add_db.rb
+++ b/chef/data_bags/crowbar/migrate/nova_dashboard/004_add_db.rb
@@ -1,7 +1,15 @@
 def upgrade ta, td, a, d
   a['db'] = ta['db']
-  service = ServiceObject.new "fake-logger"
-  a['db']['password'] = service.random_password
+
+  # Old proposals had passwords created in the cookbook, but in the wrong
+  # namespace for attributes. So no need to migrate them here. We use a class
+  # variable to set the same password in the proposal and in the role, though
+  unless defined?(@@nova_dashboard_db_password)
+    service = ServiceObject.new "fake-logger"
+    @@nova_dashboard_db_password = service.random_password
+  end
+  a['db']['password'] = @@nova_dashboard_db_password
+
   return a, d
 end
 


### PR DESCRIPTION
We use a class variable for this.

Also note that there's no need to remove password from node attributes
as they are in a wrong namespace there anyway, so won't conflict.
