### PR TITLE
Use new synchronization helpers to avoid races when deploying with HA

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -197,6 +197,7 @@ db_conn = { :host => database_address,
             :username => "db_maker",
             :password => sql["database"][:db_maker_password] }
 
+crowbar_pacemaker_sync_mark "wait-nova_dashboard_database"
 
 # Create the Dashboard Database
 database "create #{node[:nova_dashboard][:db][:database]} database" do
@@ -226,6 +227,8 @@ database_user "grant database access for dashboard database user" do
     provider db_user_provider
     action :grant
 end
+
+crowbar_pacemaker_sync_mark "create-nova_dashboard_database"
 
 db_settings = {
   'ENGINE' => django_db_backend,
@@ -277,6 +280,9 @@ directory "/var/lib/openstack-dashboard" do
 end
 
 
+# We should protect this with crowbar_pacemaker_sync_mark, but because we run
+# this in a notification, we can't; we had a sync mark earlier on, though, so
+# the founder is very likely to do the db sync first and make this a non-issue.
 execute "python manage.py syncdb" do
   cwd dashboard_path
   environment ({'PYTHONPATH' => dashboard_path})


### PR DESCRIPTION
There are a number of possible races when deploying horizon for the
first time:
- when creating of the database / database user

Ideally, we would also do that for the db sync, but it's not possible
because this happens in a notification. It should be fine, though, as
the first sync for the database should give enough advance time to the
cluster founder to avoid an issue there.

This depends on https://github.com/crowbar/barclamp-pacemaker/pull/50
