### PR TITLE
Actually set the caching key prefix

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -111,7 +111,7 @@ CACHES = {
 <% @memcached_locations.each do |memcached_location| -%>
           '<%= memcached_location %>',
 <% end -%>
-        ]
+        ],
         'OPTIONS': {
           'KEY_PREFIX': '<%= node[:nova_dashboard][:config][:environment] %>'
         }


### PR DESCRIPTION
This was accidentally missing in a rebase of
https://github.com/crowbar/barclamp-nova_dashboard/pull/121

(cherry picked from commit cd434536e1bab217bdcc95cf78e789de7580b472)
