### PR TITLE
Sort memcache servers in configuration

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -309,6 +309,7 @@ if ha_enabled
 else
   memcached_locations = [ "#{node_admin_ip}:#{node[:memcached][:port]}" ]
 end
+memcached_locations.sort!
 
 memcached_instance "nova-dashboard"
 case node[:platform]


### PR DESCRIPTION
The ordering matters, otherwise lookup fails randomly
