### PR TITLE
Make fields for password injection configurable

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -34,3 +34,6 @@ default[:nova_dashboard][:ha][:ports][:ssl] = 5581
 node[:nova_dashboard][:monitor]={}
 node[:nova_dashboard][:monitor][:svcs] = []
 node[:nova_dashboard][:monitor][:ports]={}
+
+# Display password fields for Nova password injection
+default["nova_dashboard"]["can_set_password"] = false

--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -342,7 +342,8 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
     :neutron_networking_plugin => neutron_networking_plugin,
     :neutron_use_ml2 => neutron_use_ml2,
     :session_timeout => node[:nova_dashboard][:session_timeout],
-    :memcached_locations => memcached_locations
+    :memcached_locations => memcached_locations,
+    :can_set_password => node["nova_dashboard"]["can_set_password"]
   )
   notifies :run, resources(:execute => "python manage.py syncdb"), :immediately
   action :create

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -162,6 +162,7 @@ OPENSTACK_KEYSTONE_BACKEND = {
 
 OPENSTACK_HYPERVISOR_FEATURES = {
     'can_set_mount_point': True,
+    'can_set_password': <%= @can_set_password ? "True" : "False"  %>
 }
 
 # The OPENSTACK_NEUTRON_NETWORK settings can be used to enable optional

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -18,6 +18,7 @@
         "regex": ".{8,}",
         "help_text": "Your password must be at least 8 characters long."
       },
+      "can_set_password": false,
       "apache": {
         "ssl": false,
         "ssl_crt_file": "/etc/apache2/ssl.crt/openstack-dashboard-server.crt",

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -35,6 +35,7 @@
                 "help_text": { "type": "str", "required": true }
               }
             },
+            "can_set_password": { "type": "bool", "required": false },
             "apache" : {
               "type" : "map",
               "required" : true,


### PR DESCRIPTION
Nova can inject root passwords into instances. Not all hypervisors support
that feature and visibility of the password fileds can get configured.

The relevant patch is not upstreamable, so this is only effective when
the dashboard package from the openSUSE build service is used.

Configure nova_dashboard to not disply the password fields.

Bugzilla entry: https://bugzilla.novell.com/show_bug.cgi?id=869696
