### PR TITLE
Enable Neutron LBaaS / VPNaaS in the Horizon UI

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -265,10 +265,14 @@ if neutrons.length > 0
   neutron_insecure = neutron[:neutron][:api][:protocol] == 'https' && neutron[:neutron][:ssl][:insecure]
   neutron_networking_plugin = neutron[:neutron][:networking_plugin]
   neutron_use_ml2 = neutron[:neutron][:use_ml2]
+  neutron_use_lbaas = neutron[:neutron][:use_lbaas]
+  neutron_use_vpnaas = neutron[:neutron][:use_vpnaas]
 else
   neutron_insecure = false
   neutron_networking_plugin = ""
   neutron_use_ml2 = false
+  neutron_use_lbaas = false
+  neutron_use_vpnaas = false
 end
 
 nova = get_instance('roles:nova-multi-controller')
@@ -332,6 +336,8 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
     :keystone_settings => keystone_settings,
     :insecure => keystone_settings['insecure'] || glance_insecure || cinder_insecure || neutron_insecure || nova_insecure,
     :db_settings => db_settings,
+    :enable_lb => neutron_use_lbaas,
+    :enable_vpn => neutron_use_vpnaas,
     :timezone => (node[:provisioner][:timezone] rescue "UTC") || "UTC",
     :use_ssl => node[:nova_dashboard][:apache][:ssl],
     :password_validator_regex => node[:nova_dashboard][:password_validator][:regex],

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -168,10 +168,10 @@ OPENSTACK_HYPERVISOR_FEATURES = {
 # services provided by neutron. Options currenly available are load
 # balancer service, security groups, quotas, VPN service.
 OPENSTACK_NEUTRON_NETWORK = {
-    'enable_lb': False,
-    'enable_firewall': False,
+    'enable_lb': <%= @enable_lb ? 'True' : 'False' %>,
+    'enable_firewall': True,
     'enable_quotas': True,
-    'enable_vpn': False,
+    'enable_vpn': <%= @enable_vpn ? 'True' : 'False' %>,
     # The profile_support option is used to detect if an external router can be
     # configured via the dashboard. When using specific plugins the
     # profile_support can be turned on if needed.


### PR DESCRIPTION
Enable Access to LBaaS and VPNaaS in the Horizon UI
if configured.
