### PR TITLE
Make the can_set_mount_point hypervisor option configurable

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -36,5 +36,6 @@ node[:nova_dashboard][:monitor]={}
 node[:nova_dashboard][:monitor][:svcs] = []
 node[:nova_dashboard][:monitor][:ports]={}
 
+default["nova_dashboard"]["can_set_mount_point"] = false
 # Display password fields for Nova password injection
 default["nova_dashboard"]["can_set_password"] = false

--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -348,6 +348,7 @@ template "#{dashboard_path}/openstack_dashboard/local/local_settings.py" do
     :neutron_use_ml2 => neutron_use_ml2,
     :session_timeout => node[:nova_dashboard][:session_timeout],
     :memcached_locations => memcached_locations,
+    :can_set_mount_point => node["nova_dashboard"]["can_set_mount_point"],
     :can_set_password => node["nova_dashboard"]["can_set_password"]
   )
   notifies :run, resources(:execute => "python manage.py syncdb"), :immediately

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -161,7 +161,7 @@ OPENSTACK_KEYSTONE_BACKEND = {
 }
 
 OPENSTACK_HYPERVISOR_FEATURES = {
-    'can_set_mount_point': True,
+    'can_set_mount_point': <%= @can_set_mount_point ? "True" : "False"  %>,
     'can_set_password': <%= @can_set_password ? "True" : "False"  %>
 }
 

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -19,6 +19,7 @@
         "regex": ".{8,}",
         "help_text": "Your password must be at least 8 characters long."
       },
+      "can_set_mount_point": false,
       "can_set_password": false,
       "apache": {
         "ssl": false,

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -36,6 +36,7 @@
                 "help_text": { "type": "str", "required": true }
               }
             },
+            "can_set_mount_point": { "type": "bool", "required": false },
             "can_set_password": { "type": "bool", "required": false },
             "apache" : {
               "type" : "map",


### PR DESCRIPTION
As the mount point can only be set with Xen, many people might not want
to have the field for this visible. So we add an option for this, which
defaults to False.

Note that there's no schema migration since the new attribute is
optional.

See also https://bugs.launchpad.net/horizon/+bug/1255136
