### PR TITLE
Fix redirection of non-SSL to SSL website when using HA

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
@@ -4,7 +4,10 @@
 
 RewriteEngine On
 RewriteCond %{SERVER_PORT} ^<%= @bind_port %>$
-RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
+RewriteCond %{REQUEST_URI} !^/server-status
+# Remove port from HTTP_HOST
+RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On


### PR DESCRIPTION
We need to use the correct port for redirecting (instead of leaving the
non-ssl port), and we need to leave the /server-status page unredirected
(since it's used by pacemaker
