### PR TITLE
Use a host specific memcache key for django_compressor

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -118,6 +118,10 @@ CACHES = {
     }
 }
 
+# Make sure that django_compressor uses a host specific cache key
+# as we do not use a shared filesystem for the static assets
+COMPRESS_CACHE_KEY_FUNCTION='compressor.cache.socket_cachekey'
+
 # Send email to the console by default
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # Or send them to /dev/null


### PR DESCRIPTION
Otherwise all but one node in the HA cluster will miss
the static assets, causing ugliness and 404 messages in
the browser.

Fixes
https://bugzilla.novell.com/show_bug.cgi?id=894070
