### PR TITLE
Use seperated STATIC_ROOT

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -276,7 +276,9 @@ template local_settings do
     :session_timeout => node[:nova_dashboard][:session_timeout],
     :memcached_locations => memcached_locations,
     :can_set_mount_point => node["nova_dashboard"]["can_set_mount_point"],
-    :can_set_password => node["nova_dashboard"]["can_set_password"]
+    :can_set_password => node["nova_dashboard"]["can_set_password"],
+    :horizon_dir => dashboard_path
+
   )
   action :create
 end

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -36,6 +36,8 @@ OPENSTACK_API_VERSIONS = {
     "identity": 2.0
 }
 
+STATIC_ROOT = "<%= @horizon_dir %>/static"
+
 # Set this to True if running on multi-domain model. When this is enabled, it
 # will require user to enter the Domain name in addition to username for login.
 # OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = False

--- a/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
@@ -28,7 +28,7 @@ RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
 
     DocumentRoot <%= @horizon_dir %>
     Alias /media <%= @horizon_dir %>/openstack_dashboard/media
-    Alias /static <%= @horizon_dir %>/openstack_dashboard/static
+    Alias /static <%= @horizon_dir %>/static
 
     <Location /static>
         SetOutputFilter DEFLATE


### PR DESCRIPTION
The STATIC_ROOT directory should be an empty dir before
runing i.e. ./manage.py collectstatic.
