### PR TITLE
Disable SSLv2/v3 to avoid POODLE weakness (CVE-2014-3566)

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/centos/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/centos/nova-dashboard.conf.erb
@@ -8,6 +8,8 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
+    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>
     <% unless @ssl_crt_chain_file.nil? or @ssl_crt_chain_file.empty? %>

--- a/chef/cookbooks/nova_dashboard/templates/default/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/nova-dashboard.conf.erb
@@ -8,6 +8,8 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
+    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>
     <% unless @ssl_crt_chain_file.nil? or @ssl_crt_chain_file.empty? %>

--- a/chef/cookbooks/nova_dashboard/templates/redhat/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/redhat/nova-dashboard.conf.erb
@@ -8,6 +8,8 @@ RewriteRule / https://%{HTTP_HOST}%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
+    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>
     <% unless @ssl_crt_chain_file.nil? or @ssl_crt_chain_file.empty? %>

--- a/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
@@ -11,6 +11,8 @@ RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On
+    SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH
+    SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile <%= @ssl_crt_file %>
     SSLCertificateKeyFile <%= @ssl_key_file %>
     <% unless @ssl_crt_chain_file.nil? or @ssl_crt_chain_file.empty? %>


### PR DESCRIPTION
Also set a more sane default set of ciphers to enable.
