### PR TITLE
Fix redirection from non-ssl to ssl when using HA (bnc#907044)

### DIFF
--- a/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
@@ -2,12 +2,27 @@
 <IfDefine SSL>
 <IfDefine !NOSSL>
 
-RewriteEngine On
-RewriteCond %{SERVER_PORT} ^<%= @bind_port %>$
-RewriteCond %{REQUEST_URI} !^/server-status
-# Remove port from HTTP_HOST
-RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
-RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
+# Redirect non-SSL traffic to SSL
+<VirtualHost <%= @bind_host %>:<%= @bind_port %>>
+    RewriteEngine On
+
+    # If request was explicit about this port, then we redirect with the
+    # explicit SSL port. This is needed in the HA case, where we use
+    # non-standard ports.
+    RewriteCond %{REQUEST_URI} !^/server-status
+    # Extract port
+    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+    RewriteCond %2 ^:<%= @bind_port %>$
+    # Remove port from HTTP_HOST
+    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+    RewriteRule / https://%1:<%= @bind_port_ssl %>%{REQUEST_URI} [L,R]
+
+    # Otherwise, we simply redirect to https.
+    RewriteCond %{REQUEST_URI} !^/server-status
+    # Remove port from HTTP_HOST
+    RewriteCond %{HTTP_HOST} ^([^:]+)(:[0-9]+)?$
+    RewriteRule / https://%1%{REQUEST_URI} [L,R]
+</VirtualHost>
 
 <VirtualHost <%= @bind_host %>:<%= @bind_port_ssl %>>
     SSLEngine On


### PR DESCRIPTION
Two things were broken:
- without the VirtualHost for non-ssl port, the rewrite was not working
  when a request was coming from haproxy as the requested port was
  really 80, not 5580 (and we had a RewriteCond filtering this out).
  Now VirtualHost is the way we restrict the rewrite rules to the
  requests we care about.
- we shouldn't redirect to port 5581 for requests coming through
  haproxy because 5581 is not visible from the outside. So what we do
  is that we only redirect to an explicit port for ssl when the
  explicit port for non-ssl is the one we listen on. Otherwise, we just
  redirect to the host.

https://bugzilla.suse.com/show_bug.cgi?id=907044
(cherry picked from commit b850d50c3ff75cd2803acea0f0936a6095c70832)
