### PR TITLE
Use X-Forwarded-For IP address in logs when behind haproxy

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -321,6 +321,7 @@ template "#{node[:apache][:dir]}/sites-available/nova-dashboard.conf" do
   source "nova-dashboard.conf.erb"
   mode 0644
   variables(
+    :behind_proxy => ha_enabled,
     :bind_host => bind_host,
     :bind_port => bind_port,
     :bind_port_ssl => bind_port_ssl,

--- a/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
+++ b/chef/cookbooks/nova_dashboard/templates/suse/nova-dashboard.conf.erb
@@ -69,7 +69,12 @@
 
     ErrorLog /var/log/apache2/openstack-dashboard-error_log
     LogLevel warn
+    <% if @behind_proxy -%>
+    LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy_combined
+    CustomLog /var/log/apache2/openstack-dashboard-access_log proxy_combined
+    <% else -%>
     CustomLog /var/log/apache2/openstack-dashboard-access_log combined
+    <% end -%>
 </VirtualHost>
 
 <% if @use_ssl %>


### PR DESCRIPTION
This is much more useful than logging the IP address of the haproxy
server.

This depends on https://github.com/crowbar/barclamp-pacemaker/pull/171