### PR TITLE
Do not point to docs in site_branding_link by default (bnc#917665)

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -20,7 +20,7 @@ default[:nova_dashboard][:db][:password] = nil # must be set by wrapper
 default[:nova_dashboard][:debug] = false
 default[:nova_dashboard][:site_branding] = "OpenStack Dashboard"
 default[:nova_dashboard][:site_theme] = ""
-default[:nova_dashboard][:site_branding_link] = "http://docs.openstack.org/"
+default[:nova_dashboard][:site_branding_link] = ""
 
 default[:nova_dashboard][:apache][:ssl] = false
 default[:nova_dashboard][:apache][:ssl_crt_file] = '/etc/apache2/ssl.crt/openstack-dashboard-server.crt'

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -568,7 +568,9 @@ DATABASES = {
 }
 
 SITE_BRANDING = "<%= @site_branding %>"
+<% unless @site_branding_link.empty? -%>
 SITE_BRANDING_LINK = "<%= @site_branding_link %>"
+<% end -%>
 
 <% if node[:nova_dashboard].has_key?(:external_monitoring) -%>
 EXTERNAL_MONITORING = [

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -9,7 +9,7 @@
       "database_instance": "none",
       "site_branding": "OpenStack Dashboard",
       "site_theme": "",
-      "site_branding_link": "http://docs.openstack.org/",
+      "site_branding_link": "",
       "session_timeout": 1440,
       "db": {
         "database": "horizon",


### PR DESCRIPTION
This hardly makes sense, and the default from Horizon is much saner.

https://bugzilla.suse.com/show_bug.cgi?id=917665