### PR TITLE
Use local_settings_theme.py when SITE_BRANDING* are not defined

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -18,7 +18,7 @@ default[:nova_dashboard][:db][:user] = "horizon"
 default[:nova_dashboard][:db][:password] = nil # must be set by wrapper
 
 default[:nova_dashboard][:debug] = false
-default[:nova_dashboard][:site_branding] = "OpenStack Dashboard"
+default[:nova_dashboard][:site_branding] = ""
 default[:nova_dashboard][:site_theme] = ""
 default[:nova_dashboard][:site_branding_link] = ""
 default[:nova_dashboard][:help_url] = "http://docs.openstack.org/"

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -563,8 +563,20 @@ DATABASES = {
     },
 }
 
+<% unless @site_branding.empty? -%>
+try:
+    from local_settings_theme import SITE_BRANDING  # noqa
+except ImportError:
+    logging.debug("No SITE_BRANDING found in local_settings_theme.")
+<% else -%>
 SITE_BRANDING = "<%= @site_branding %>"
+<% end -%>
 <% unless @site_branding_link.empty? -%>
+try:
+    from local_settings_theme import SITE_BRANDING_LINK  # noqa
+except ImportError:
+    logging.debug("No SITE_BRANDING_LINK found in local_settings_theme.")
+<% else -%>
 SITE_BRANDING_LINK = "<%= @site_branding_link %>"
 <% end -%>
 

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -7,7 +7,7 @@
       "nova_instance": "none",
       "keystone_instance": "none",
       "database_instance": "none",
-      "site_branding": "OpenStack Dashboard",
+      "site_branding": "",
       "site_theme": "",
       "site_branding_link": "",
       "help_url": "http://docs.openstack.org/",


### PR DESCRIPTION
The SITE_BRANDING and SITE_BRANDING_LINK settings can now be defined in
a local_settings_theme.py file, that the theme can provide. If the
settings are not set in the proposal, then the values from the theme
would be used.