### PR TITLE
Enable the POLICY_FILES setting configuration.

### DIFF
--- a/chef/cookbooks/nova_dashboard/attributes/default.rb
+++ b/chef/cookbooks/nova_dashboard/attributes/default.rb
@@ -23,6 +23,15 @@ default[:nova_dashboard][:site_theme] = ""
 default[:nova_dashboard][:site_branding_link] = ""
 default[:nova_dashboard][:help_url] = "http://docs.openstack.org/"
 
+default[:nova_dashboard][:policy_file_path] = ""
+
+default[:nova_dashboard][:policy_file][:identity] = "keystone_policy.json"
+default[:nova_dashboard][:policy_file][:compute] = "nova_policy.json"
+default[:nova_dashboard][:policy_file][:volume] = "cinder_policy.json"
+default[:nova_dashboard][:policy_file][:image] = "glance_policy.json"
+default[:nova_dashboard][:policy_file][:orchestration] = "heat_policy.json"
+default[:nova_dashboard][:policy_file][:network] = "neutron_policy.json"
+
 default[:nova_dashboard][:apache][:ssl] = false
 default[:nova_dashboard][:apache][:ssl_crt_file] = '/etc/apache2/ssl.crt/openstack-dashboard-server.crt'
 default[:nova_dashboard][:apache][:ssl_key_file] = '/etc/apache2/ssl.key/openstack-dashboard-server.key'

--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -289,7 +289,11 @@ template local_settings do
     :session_timeout => node[:nova_dashboard][:session_timeout],
     :memcached_locations => memcached_locations,
     :can_set_mount_point => node["nova_dashboard"]["can_set_mount_point"],
-    :can_set_password => node["nova_dashboard"]["can_set_password"]
+    :can_set_password => node["nova_dashboard"]["can_set_password"],
+    :keystone_api_version => keystone_api_version,
+    :keystone_internal_auth_url => keystone_internal_auth_url,
+    :policy_file_path => nova["nova_dashboard"]["policy_file_path"],
+    :policy_file => node["nova_dashboard"]["policy_file"]
   )
   action :create
 end
@@ -366,4 +370,3 @@ end
 
 node[:nova_dashboard][:monitor][:svcs] <<["nova_dashboard-server"]
 node.save
-

--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -292,7 +292,7 @@ template local_settings do
     :can_set_password => node["nova_dashboard"]["can_set_password"],
     :keystone_api_version => keystone_api_version,
     :keystone_internal_auth_url => keystone_internal_auth_url,
-    :policy_file_path => nova["nova_dashboard"]["policy_file_path"],
+    :policy_file_path => node["nova_dashboard"]["policy_file_path"],
     :policy_file => node["nova_dashboard"]["policy_file"]
   )
   action :create

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -290,16 +290,20 @@ TIME_ZONE = "<%= @timezone %>"
 # target installation.
 
 # Path to directory containing policy.json files
-#POLICY_FILES_PATH = os.path.join(ROOT_PATH, "conf")
+<% if @policy_file_path.empty? -%>
+#POLICY_FILES_PATH = os.path.join(ROOT_PATH, 'conf')
+<% else -%>
+POLICY_FILES_PATH = '<%= @policy_file_path =>'
+<% end -%>
 # Map of local copy of service policy files
-#POLICY_FILES = {
-#    'identity': 'keystone_policy.json',
-#    'compute': 'nova_policy.json',
-#    'volume': 'cinder_policy.json',
-#    'image': 'glance_policy.json',
-#    'orchestration': 'heat_policy.json',
-#    'network': 'neutron_policy.json',
-#}
+POLICY_FILES = {
+    'identity': '<%= @policy_file[:identity] =>',
+    'compute': '<%= @policy_file[:compute] =>',
+    'volume': '<%= @policy_file[:volume] =>',
+    'image': '<%= @policy_file[:image] =>',
+    'orchestration': '<%= @policy_file[:orchestration] =>',
+    'network': '<%= @policy_file[:network] =>',
+}
 
 # Trove user and database extension support. By default support for
 # creating users and databases on database instances is turned on.

--- a/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
+++ b/chef/cookbooks/nova_dashboard/templates/default/local_settings.py.erb
@@ -293,16 +293,16 @@ TIME_ZONE = "<%= @timezone %>"
 <% if @policy_file_path.empty? -%>
 #POLICY_FILES_PATH = os.path.join(ROOT_PATH, 'conf')
 <% else -%>
-POLICY_FILES_PATH = '<%= @policy_file_path =>'
+POLICY_FILES_PATH = '<%= @policy_file_path %>'
 <% end -%>
 # Map of local copy of service policy files
 POLICY_FILES = {
-    'identity': '<%= @policy_file[:identity] =>',
-    'compute': '<%= @policy_file[:compute] =>',
-    'volume': '<%= @policy_file[:volume] =>',
-    'image': '<%= @policy_file[:image] =>',
-    'orchestration': '<%= @policy_file[:orchestration] =>',
-    'network': '<%= @policy_file[:network] =>',
+    'identity': '<%= @policy_file[:identity] %>',
+    'compute': '<%= @policy_file[:compute] %>',
+    'volume': '<%= @policy_file[:volume] %>',
+    'image': '<%= @policy_file[:image] %>',
+    'orchestration': '<%= @policy_file[:orchestration] %>',
+    'network': '<%= @policy_file[:network] %>',
 }
 
 # Trove user and database extension support. By default support for

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -21,6 +21,15 @@
         "regex": ".{8,}",
         "help_text": "Your password must be at least 8 characters long."
       },
+      "policy_file_path": "",
+      "policy_file": {
+        "identity": "keystone_policy.json",
+        "compute": "nova_policy.json",
+        "volume": "cinder_policy.json",
+        "image": "glance_policy.json",
+        "orchestration": "heat_policy.json",
+        "network": "neutron_policy.json"
+      },
       "can_set_mount_point": false,
       "can_set_password": false,
       "apache": {
@@ -53,7 +62,7 @@
     "nova_dashboard": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 21,
+      "schema-revision": 22,
       "element_states": {
         "nova_dashboard-server": [ "readying", "ready", "applying" ]
       },
@@ -71,4 +80,3 @@
     }
   }
 }
-

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -38,6 +38,15 @@
                 "help_text": { "type": "str", "required": true }
               }
             },
+            "policy_file_path" : { "type": "str", "required": true },
+            "policy_file" : {
+              "identity" : { "type": "str", "required": true },
+              "compute" : { "type": "str", "required": true },
+              "volume" : { "type": "str", "required": true },
+              "image" : { "type": "str", "required": true },
+              "orchestration" : { "type": "str", "required": true },
+              "network" : { "type": "str", "required": true }
+	    },
             "can_set_mount_point": { "type": "bool", "required": false },
             "can_set_password": { "type": "bool", "required": false },
             "apache" : {

--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.schema
@@ -40,13 +40,17 @@
             },
             "policy_file_path" : { "type": "str", "required": true },
             "policy_file" : {
-              "identity" : { "type": "str", "required": true },
-              "compute" : { "type": "str", "required": true },
-              "volume" : { "type": "str", "required": true },
-              "image" : { "type": "str", "required": true },
-              "orchestration" : { "type": "str", "required": true },
-              "network" : { "type": "str", "required": true }
-	    },
+              "type" : "map",
+              "required" : true,
+              "mapping": {
+                "identity" : { "type": "str", "required": true },
+                "compute" : { "type": "str", "required": true },
+                "volume" : { "type": "str", "required": true },
+                "image" : { "type": "str", "required": true },
+                "orchestration" : { "type": "str", "required": true },
+                "network" : { "type": "str", "required": true }
+              }
+            },
             "can_set_mount_point": { "type": "bool", "required": false },
             "can_set_password": { "type": "bool", "required": false },
             "apache" : {

--- a/chef/data_bags/crowbar/migrate/nova_dashboard/022_add_policy_file.rb
+++ b/chef/data_bags/crowbar/migrate/nova_dashboard/022_add_policy_file.rb
@@ -1,0 +1,11 @@
+def upgrade ta, td, a, d
+  a['policy_file_path'] = ta['policy_file_path']
+  a['policy_file'] = ta['policy_file']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('policy_file_path')
+  a.delete('policy_file')
+  return a, d
+end


### PR DESCRIPTION
Add six new fields to configure POLICY_FILES dictionary in Horizon
settings (local_settings.py) file.

(cherry picked from commit 527bb4a3e409f8ea2017170d0a07ea9df4cfe9db)
(cherry picked from commit 4237bc3a7fbf1fddb5e9fdfc0f7661a8e67811b4)