### PR TITLE
Fix quoting of supported_provider_types (bsc#936368)

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -206,13 +206,13 @@ if neutrons.length > 0
   if neutron[:neutron][:networking_plugin] == 'ml2'
     neutron_ml2_type_drivers = neutron[:neutron][:ml2_type_drivers]
   else
-    neutron_ml2_type_drivers = "*"
+    neutron_ml2_type_drivers = "'*'"
   end
   neutron_use_lbaas = neutron[:neutron][:use_lbaas]
   neutron_use_vpnaas = neutron[:neutron][:use_vpnaas]
 else
   neutron_insecure = false
-  neutron_ml2_type_drivers = "*"
+  neutron_ml2_type_drivers = "'*'"
   neutron_use_lbaas = false
   neutron_use_vpnaas = false
 end


### PR DESCRIPTION
Otherwise in case it is not a valid python identifer,
start of dashboard will fail.