### PR TITLE
Add warning for horizon timeout

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -11,7 +11,7 @@
       "site_theme": "",
       "site_branding_link": "",
       "help_url": "http://docs.openstack.org/",
-      "session_timeout": 1440,
+      "session_timeout": 240,
       "db": {
         "database": "horizon",
         "user": "horizon",

--- a/crowbar_framework/app/models/nova_dashboard_service.rb
+++ b/crowbar_framework/app/models/nova_dashboard_service.rb
@@ -93,6 +93,18 @@ class NovaDashboardService < PacemakerServiceObject
         validation_error("Multi domain support requires enabling Keystone V3 API in the keystone proposal first.")
       end
     end
+    
+    horizon_timeout = proposal["attributes"]["nova_dashboard"]["session_timeout"]
+    keystone_proposal = ProposalObject.find_proposal("keystone", "default")
+    unless keystone_proposal.nil?
+      keystone_timeout = keystone_proposal["attributes"]["keystone"]["token_expiration"]
+
+      # keystone_timeout is in seconds and horizon_timeout is in minutes
+      if horizon_timeout * 60 > keystone_timeout
+        validation_error("Setting the Horizon timeout (#{horizon_timeout} minutes) longer than the "\
+          "Keystone token expiration timeout (#{keystone_timeout / 60} minutes) is not supported.")
+      end
+    end
 
     super
   end


### PR DESCRIPTION
Horizon timeout is impacted by keystone token timeout since when the
token gets outdated, then the user is automatically unable to use
horizon. This patch includes a check for the timeout of horizon and
keystone barclamps.

The default horizon session timeout has been reduced from 24 hours
to 4 hours to match keystone token expiration.
