### PR TITLE
increase timeout for synchronization of horizon HA resources (bsc#935…

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/ha.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/ha.rb
@@ -37,7 +37,9 @@ end
 crowbar_pacemaker_sync_mark "sync-nova_dashboard_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-nova_dashboard_ha_resources"
+crowbar_pacemaker_sync_mark "wait-nova_dashboard_ha_resources" do
+  timeout 180
+end
 
 include_recipe "crowbar-pacemaker::apache"
 


### PR DESCRIPTION
…462)

Horizon HA resources can take over 1 minute to be set up, as
seen by mkcloud failures in ci.suse.de Jenkins.

Cherry-picked from f8ef6a007d1d67fc390b8c305cc9d012f623c8e7 (crowbar-openstack)
