### PR TITLE
only check for certificate if it is not created later (bsc#960006)

### DIFF
--- a/chef/cookbooks/nova_dashboard/recipes/server.rb
+++ b/chef/cookbooks/nova_dashboard/recipes/server.rb
@@ -270,7 +270,7 @@ end
 multi_domain_support = keystone_settings["api_version"].to_f < 3.0 ? false : node["nova_dashboard"]["multi_domain_support"]
 
 # Verify that we have the certificate available before configuring things to use it
-if node[:nova_dashboard][:apache][:ssl]
+if node[:nova_dashboard][:apache][:ssl] and node[:nova_dashboard][:apache][:ssl_crt_file] != "/etc/apache2/ssl.crt/openstack-dashboard-server.crt"
   unless ::File.size? node[:nova_dashboard][:apache][:ssl_crt_file]
     message = "The file \"#{node[:nova_dashboard][:apache][:ssl_crt_file]}\" does not exist or is empty."
     Chef::Log.fatal(message)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=960006#c20
openstack-dashboard creates
/etc/apache2/ssl.crt/openstack-dashboard-server.crt
upon package installation, so we must not error out before that.
