### PR TITLE
Fix Horizon and Keystone timeouts during upgrade(bsc#968102)

### DIFF
--- a/chef/data_bags/crowbar/bc-template-nova_dashboard.json
+++ b/chef/data_bags/crowbar/bc-template-nova_dashboard.json
@@ -63,7 +63,7 @@
     "nova_dashboard": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 25,
+      "schema-revision": 26,
       "element_states": {
         "nova_dashboard-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/migrate/nova_dashboard/026_use_keystone_session_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/nova_dashboard/026_use_keystone_session_timeout.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  keystone_instance = a['keystone_instance']
+  proposal_obj = ProposalObject.find_proposal("keystone", keystone_instance)
+  keystone_timeout = (proposal_obj["attributes"]["keystone"]["token_expiration"] || 14400)/60
+  if proposal_obj && a['session_timeout'] > keystone_timeout
+    a['session_timeout'] = keystone_timeout
+  end
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  return a, d
+end


### PR DESCRIPTION
Fix for https://bugzilla.suse.com/show_bug.cgi?id=968102. During upgrade, force nova-dashboard session_timeout to use keystone_timeout if it is larger than keystone_timeout .
